### PR TITLE
Added alternative names for `fn describe` and `fn it`

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ to help without knowing how. Some issues are mentored!
 - Thomas WICKHAM [@mackwic](https://github.com/mackwic)
 - Pascal HERTLEIF [@killercup](https://github.com/killercup)
 - Matthias BOURG [@pol0nium](https://github.com/pol0nium)
+- Vincent ESCHE [@regexident](https://github.com/regexident)
 
 ## Beginners
 
@@ -193,14 +194,14 @@ described. Thinking in term of behavior has two benefits:
 - When doing TDD, it helps to make incremential steps. Just write examples of
   how to use the functions, and make this example pass, then go to the next one.
   Your tests will naturally have one clear intent, and so will be easy to debug
-  / rely on when refactoring.   
+  / rely on when refactoring.
   This is the describe/it approach, which this crate hopes to fill.
 
 - By describing behavior, we are doing an _analysis_ of our program. This
   analysis can be very useful! Say... an User Story, for example. Given the
   formalism _As a X, When Y, I want Z_, you can assign scenarii describing the
   high-level behavior of your units. The Gherkin formalism is often employed for
-  this, it use a _Given X, When Y, Then Z_ structure.   
+  this, it use a _Given X, When Y, Then Z_ structure.
   This project does not aim to help on high-level BDD, see [the cucumber for
   Rust port](https://github.com/acmcarther/cucumbe://github.com/acmcarther/cucumber)
   for that.
@@ -227,5 +228,3 @@ In non legal terms it means that:
 
 This section DOES NOT REPLACE NOR COMPLETE the LICENCE files. The LICENCE file
 is the only place where the licence of tis project is defined.
-
-

--- a/examples/given_when_then.rs
+++ b/examples/given_when_then.rs
@@ -1,0 +1,20 @@
+
+extern crate rspec;
+use rspec::context::describe;
+use std::io;
+
+pub fn main() {
+    let stdout = &mut io::stdout();
+    let mut formatter = rspec::formatter::Simple::new(stdout);
+    let mut runner = describe("rspec allows for Cucumber-style BDD testing", |ctx| {
+        ctx.given("A known state of the subject", |ctx| {
+            ctx.when("a key action is performed", |ctx| {
+                ctx.then("the outputs can be observed", || {
+                    Err(()) as Result<(),()>
+                });
+            });
+        });
+    });
+    runner.add_event_handler(&mut formatter);
+    runner.run().unwrap();
+}


### PR DESCRIPTION
Attempts to fix issues https://github.com/mackwic/rspec/issues/5 and https://github.com/mackwic/rspec/issues/6.

I also added the popular `given` -> `when` -> `then` variants while I was at it.