### PR TITLE
Remove restrictions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rspec"
 description = "Write Rspec-like tests with stable rust"
 version = "1.0.0"
+edition = "2018"
 
 readme = "README.md"
 repository = "https://github.com/rust-rspec/rspec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ version = "0.0.153"
 colored = "2.0"
 derive-new = "0.5"
 derive_builder = "0.9"
-rayon = "1.5"
 time = "0.2"
 
 [dependencies.expectest]

--- a/src/block/context.rs
+++ b/src/block/context.rs
@@ -8,9 +8,9 @@
 //! Running these tests and doing asserts is not the job of the Context, but the Runner.
 //!
 
-use block::{Block, Example};
-use header::{ContextHeader, ContextLabel, ExampleHeader, ExampleLabel};
-use report::ExampleResult;
+use crate::block::{Block, Example};
+use crate::header::{ContextHeader, ContextLabel, ExampleHeader, ExampleLabel};
+use crate::report::ExampleResult;
 
 /// Test contexts are a convenient tool for adding structure and code sharing to a test suite.
 pub struct Context<T> {
@@ -531,7 +531,7 @@ impl<T> Default for Context<T> {
 
 #[cfg(test)]
 mod tests {
-    use block::{describe, given, suite};
+    use crate::block::{describe, given, suite};
 
     macro_rules! test_suite_alias {
         ($suite: ident) => {

--- a/src/block/context.rs
+++ b/src/block/context.rs
@@ -47,12 +47,6 @@ impl<T> Context<T> {
     }
 }
 
-// Both `Send` and `Sync` are necessary for parallel threaded execution.
-unsafe impl<T> Send for Context<T> where T: Send {}
-
-// Both `Send` and `Sync` are necessary for parallel threaded execution.
-unsafe impl<T> Sync for Context<T> where T: Sync {}
-
 impl<T> Context<T>
 where
     T: Clone,
@@ -98,7 +92,6 @@ where
     pub fn context<F>(&mut self, name: &'static str, body: F)
     where
         F: FnOnce(&mut Context<T>),
-        T: ::std::fmt::Debug,
     {
         let header = ContextHeader {
             label: ContextLabel::Context,
@@ -115,7 +108,6 @@ where
     pub fn specify<F>(&mut self, name: &'static str, body: F)
     where
         F: FnOnce(&mut Context<T>),
-        T: ::std::fmt::Debug,
     {
         let header = ContextHeader {
             label: ContextLabel::Specify,
@@ -132,7 +124,6 @@ where
     pub fn when<F>(&mut self, name: &'static str, body: F)
     where
         F: FnOnce(&mut Context<T>),
-        T: ::std::fmt::Debug,
     {
         let header = ContextHeader {
             label: ContextLabel::When,
@@ -187,7 +178,6 @@ where
     pub fn scope<F>(&mut self, body: F)
     where
         F: FnOnce(&mut Context<T>),
-        T: ::std::fmt::Debug,
     {
         self.context_internal(None, body)
     }
@@ -195,7 +185,6 @@ where
     fn context_internal<F>(&mut self, header: Option<ContextHeader>, body: F)
     where
         F: FnOnce(&mut Context<T>),
-        T: ::std::fmt::Debug,
     {
         let mut child = Context::new(header);
         body(&mut child);

--- a/src/block/example.rs
+++ b/src/block/example.rs
@@ -36,6 +36,3 @@ impl<T> Example<T> {
         Example::new(ExampleHeader::default(), |_| ExampleResult::Failure(None))
     }
 }
-
-unsafe impl<T> Send for Example<T> where T: Send {}
-unsafe impl<T> Sync for Example<T> where T: Sync {}

--- a/src/block/example.rs
+++ b/src/block/example.rs
@@ -1,5 +1,5 @@
-use header::ExampleHeader;
-use report::ExampleResult;
+use crate::header::ExampleHeader;
+use crate::report::ExampleResult;
 
 /// Test examples are the smallest unit of a testing framework, wrapping one or more assertions.
 pub struct Example<T> {

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -4,9 +4,9 @@ pub mod context;
 pub mod example;
 pub mod suite;
 
-pub use block::context::*;
-pub use block::example::*;
-pub use block::suite::*;
+pub use crate::block::context::*;
+pub use crate::block::example::*;
+pub use crate::block::suite::*;
 
 /// Blocks are used to build a tree structure of named tests and contextes.
 pub enum Block<T> {

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -22,6 +22,3 @@ impl<T> Block<T> {
         }
     }
 }
-
-unsafe impl<T> Send for Block<T> where T: Send {}
-unsafe impl<T> Sync for Block<T> where T: Sync {}

--- a/src/block/suite.rs
+++ b/src/block/suite.rs
@@ -23,9 +23,6 @@ impl<T> Suite<T> {
     }
 }
 
-unsafe impl<T> Send for Suite<T> where T: Send {}
-unsafe impl<T> Sync for Suite<T> where T: Sync {}
-
 /// Creates a test suite from a given root context.
 ///
 /// # Examples
@@ -62,7 +59,7 @@ unsafe impl<T> Sync for Suite<T> where T: Sync {}
 pub fn suite<F, T>(name: &'static str, environment: T, body: F) -> Suite<T>
 where
     F: FnOnce(&mut Context<T>),
-    T: Clone + ::std::fmt::Debug,
+    T: Clone,
 {
     let header = SuiteHeader {
         label: SuiteLabel::Suite,
@@ -79,7 +76,7 @@ where
 pub fn describe<F, T>(name: &'static str, environment: T, body: F) -> Suite<T>
 where
     F: FnOnce(&mut Context<T>),
-    T: Clone + ::std::fmt::Debug,
+    T: Clone,
 {
     let header = SuiteHeader {
         label: SuiteLabel::Describe,
@@ -96,7 +93,7 @@ where
 pub fn given<F, T>(name: &'static str, environment: T, body: F) -> Suite<T>
 where
     F: FnOnce(&mut Context<T>),
-    T: Clone + ::std::fmt::Debug,
+    T: Clone,
 {
     let header = SuiteHeader {
         label: SuiteLabel::Given,
@@ -108,7 +105,7 @@ where
 fn suite_internal<F, T>(header: SuiteHeader, environment: T, body: F) -> Suite<T>
 where
     F: FnOnce(&mut Context<T>),
-    T: Clone + ::std::fmt::Debug,
+    T: Clone,
 {
     let mut ctx = Context::new(None);
     body(&mut ctx);

--- a/src/block/suite.rs
+++ b/src/block/suite.rs
@@ -1,5 +1,5 @@
-use block::Context;
-use header::{SuiteHeader, SuiteLabel};
+use crate::block::Context;
+use crate::header::{SuiteHeader, SuiteLabel};
 
 /// Test suites bundle a set of closely related test examples into a logical execution group.
 #[derive(new)]

--- a/src/header/context.rs
+++ b/src/header/context.rs
@@ -39,7 +39,7 @@ mod tests {
     fn label_fmt() {
         fn subject(label: ContextLabel) -> String {
             format!("{}", label)
-        };
+        }
         assert_eq!(subject(ContextLabel::Context), "Context".to_owned());
         assert_eq!(subject(ContextLabel::Specify), "Specify".to_owned());
         assert_eq!(subject(ContextLabel::When), "When".to_owned());
@@ -49,7 +49,7 @@ mod tests {
     fn header_fmt() {
         fn subject(label: ContextLabel) -> String {
             format!("{}", ContextHeader::new(label, "Test"))
-        };
+        }
         assert_eq!(
             subject(ContextLabel::Context),
             "Context \"Test\"".to_owned()

--- a/src/header/example.rs
+++ b/src/header/example.rs
@@ -47,7 +47,7 @@ mod tests {
     fn label_fmt() {
         fn subject(label: ExampleLabel) -> String {
             format!("{}", label)
-        };
+        }
         assert_eq!(subject(ExampleLabel::Example), "Example".to_owned());
         assert_eq!(subject(ExampleLabel::It), "It".to_owned());
         assert_eq!(subject(ExampleLabel::Then), "Then".to_owned());
@@ -57,7 +57,7 @@ mod tests {
     fn header_fmt() {
         fn subject(label: ExampleLabel) -> String {
             format!("{}", ExampleHeader::new(label, "Test"))
-        };
+        }
         assert_eq!(
             subject(ExampleLabel::Example),
             "Example \"Test\"".to_owned()

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -4,6 +4,6 @@ pub mod context;
 pub mod example;
 pub mod suite;
 
-pub use header::context::*;
-pub use header::example::*;
-pub use header::suite::*;
+pub use crate::header::context::*;
+pub use crate::header::example::*;
+pub use crate::header::suite::*;

--- a/src/header/suite.rs
+++ b/src/header/suite.rs
@@ -39,7 +39,7 @@ mod tests {
     fn label_fmt() {
         fn subject(label: SuiteLabel) -> String {
             format!("{}", label)
-        };
+        }
         assert_eq!(subject(SuiteLabel::Suite), "Suite".to_owned());
         assert_eq!(subject(SuiteLabel::Describe), "Describe".to_owned());
         assert_eq!(subject(SuiteLabel::Given), "Given".to_owned());
@@ -49,7 +49,7 @@ mod tests {
     fn header_fmt() {
         fn subject(label: SuiteLabel) -> String {
             format!("{}", SuiteHeader::new(label, "Test"))
-        };
+        }
         assert_eq!(subject(SuiteLabel::Suite), "Suite \"Test\"".to_owned());
         assert_eq!(
             subject(SuiteLabel::Describe),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,11 +22,11 @@ pub mod runner;
 
 mod visitor;
 
-pub use block::{describe, given, suite};
-pub use logger::Logger;
-pub use runner::{Configuration, ConfigurationBuilder, Runner};
+pub use crate::block::{describe, given, suite};
+pub use crate::logger::Logger;
+pub use crate::runner::{Configuration, ConfigurationBuilder, Runner};
 
-use block::Suite;
+use crate::block::Suite;
 
 /// A wrapper for conveniently running a test suite with
 /// the default configuration with considerebly less glue-code.
@@ -64,7 +64,7 @@ where
 mod tests {
 
     pub use super::*;
-    pub use block::*;
+    pub use crate::block::*;
 
     // Test list:
     // x check that tests can call `assert_eq!`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ extern crate derive_new;
 extern crate colored;
 #[cfg(feature = "expectest_compat")]
 extern crate expectest;
-extern crate rayon;
 extern crate time;
 
 pub mod block;
@@ -49,7 +48,7 @@ use block::Suite;
 /// ```
 pub fn run<T>(suite: &Suite<T>)
 where
-    T: Clone + Send + Sync + ::std::fmt::Debug,
+    T: Clone,
 {
     use std::io;
     use std::sync::Arc;

--- a/src/logger/mod.rs
+++ b/src/logger/mod.rs
@@ -19,10 +19,10 @@ mod serial;
 
 use std::io;
 
-use header::{ContextHeader, ExampleHeader, SuiteHeader};
-use logger::serial::SerialLogger;
-use report::{BlockReport, ContextReport, ExampleReport, SuiteReport};
-use runner::{Runner, RunnerObserver};
+use crate::header::{ContextHeader, ExampleHeader, SuiteHeader};
+use crate::logger::serial::SerialLogger;
+use crate::report::{BlockReport, ContextReport, ExampleReport, SuiteReport};
+use crate::runner::{Runner, RunnerObserver};
 
 /// Preferred logger for test suite execution.
 pub struct Logger<T: io::Write> {

--- a/src/logger/mod.rs
+++ b/src/logger/mod.rs
@@ -84,52 +84,26 @@ where
     T: Send + Sync,
 {
     fn enter_suite(&self, runner: &Runner, header: &SuiteHeader) {
-        if runner.configuration.parallel {
-            // If the suite is being evaluated in parallel we basically wait for `exit_suite`.
-        } else {
-            self.serial.enter_suite(runner, header);
-        }
+        self.serial.enter_suite(runner, header);
     }
 
     fn exit_suite(&self, runner: &Runner, header: &SuiteHeader, report: &SuiteReport) {
-        if runner.configuration.parallel {
-            // If the suite is being evaluated in parallel and we have reached the end of it,
-            // then it is time to forward a replay of the events to the inner serial logger:
-            self.replay_suite(runner, header, report);
-        } else {
-            self.serial.exit_suite(runner, header, report);
-        }
+        self.serial.exit_suite(runner, header, report);
     }
 
     fn enter_context(&self, runner: &Runner, header: &ContextHeader) {
-        if runner.configuration.parallel {
-            // If the suite is being evaluated in parallel we basically wait for `exit_suite`.
-        } else {
-            self.serial.enter_context(runner, header);
-        }
+        self.serial.enter_context(runner, header);
     }
 
     fn exit_context(&self, runner: &Runner, header: &ContextHeader, report: &ContextReport) {
-        if runner.configuration.parallel {
-            // If the suite is being evaluated in parallel we basically wait for `exit_suite`.
-        } else {
-            self.serial.exit_context(runner, header, report);
-        }
+        self.serial.exit_context(runner, header, report);
     }
 
     fn enter_example(&self, runner: &Runner, header: &ExampleHeader) {
-        if runner.configuration.parallel {
-            // If the suite is being evaluated in parallel we basically wait for `exit_suite`.
-        } else {
-            self.serial.enter_example(runner, header);
-        }
+        self.serial.enter_example(runner, header);
     }
 
     fn exit_example(&self, runner: &Runner, header: &ExampleHeader, report: &ExampleReport) {
-        if runner.configuration.parallel {
-            // If the suite is being evaluated in parallel we basically wait for `exit_suite`.
-        } else {
-            self.serial.exit_example(runner, header, report);
-        }
+        self.serial.exit_example(runner, header, report);
     }
 }

--- a/src/logger/serial.rs
+++ b/src/logger/serial.rs
@@ -6,9 +6,11 @@ use time::Duration;
 
 use colored::*;
 
-use header::{ContextHeader, ExampleHeader, SuiteHeader};
-use report::{BlockReport, ContextReport, ExampleReport, ExampleResult, Report, SuiteReport};
-use runner::{Runner, RunnerObserver};
+use crate::header::{ContextHeader, ExampleHeader, SuiteHeader};
+use crate::report::{
+    BlockReport, ContextReport, ExampleReport, ExampleResult, Report, SuiteReport,
+};
+use crate::runner::{Runner, RunnerObserver};
 
 #[derive(new)]
 struct SerialLoggerState<T: io::Write = io::Stdout> {

--- a/src/report/context.rs
+++ b/src/report/context.rs
@@ -1,4 +1,4 @@
-use report::{BlockReport, Report};
+use crate::report::{BlockReport, Report};
 use time::Duration;
 
 /// `ContextReport` holds the results of a context's test execution.

--- a/src/report/example.rs
+++ b/src/report/example.rs
@@ -2,7 +2,7 @@ use std::convert::From;
 
 use time::Duration;
 
-use report::Report;
+use crate::report::Report;
 
 #[cfg(feature = "expectest_compat")]
 use expectest::core::TestResult as ExpectestResult;

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -6,12 +6,12 @@ mod suite;
 
 pub use time::Duration;
 
-pub use report::context::*;
-pub use report::example::*;
-pub use report::suite::*;
+pub use crate::report::context::*;
+pub use crate::report::example::*;
+pub use crate::report::suite::*;
 
-use header::ContextHeader;
-use header::ExampleHeader;
+use crate::header::ContextHeader;
+use crate::header::ExampleHeader;
 
 /// `Report` holds the results of a structural group's test execution.
 pub trait Report {

--- a/src/report/suite.rs
+++ b/src/report/suite.rs
@@ -1,7 +1,7 @@
 use time::Duration;
 
-use header::SuiteHeader;
-use report::{ContextReport, Report};
+use crate::header::SuiteHeader;
+use crate::report::{ContextReport, Report};
 
 /// `SuiteReport` holds the results of a context suite's test execution.
 #[derive(PartialEq, Eq, Clone, Debug, new)]

--- a/src/runner/configuration.rs
+++ b/src/runner/configuration.rs
@@ -4,9 +4,6 @@
 /// A Runner's configuration.
 #[derive(Builder)]
 pub struct Configuration {
-    /// Whether the runner executes tests in parallel
-    #[builder(default = "true")]
-    pub parallel: bool,
     /// Whether the runner exits the procees upon encountering failures
     #[builder(default = "true")]
     pub exit_on_failure: bool,
@@ -25,7 +22,6 @@ mod tests {
     #[test]
     fn default_with_builder() {
         let config = ConfigurationBuilder::default().build().unwrap();
-        assert_eq!(config.parallel, true);
         assert_eq!(config.exit_on_failure, true);
     }
 
@@ -36,28 +32,19 @@ mod tests {
         // act
         let config = Configuration::default();
         // assert
-        assert_eq!(expected.parallel, config.parallel);
         assert_eq!(expected.exit_on_failure, config.exit_on_failure);
     }
 
     #[test]
     fn builder() {
         let config = ConfigurationBuilder::default().build().unwrap();
-        assert_eq!(config.parallel, true);
-        assert_eq!(config.exit_on_failure, true);
-
-        let config = ConfigurationBuilder::default()
-            .parallel(false)
-            .build()
-            .unwrap();
-        assert_eq!(config.parallel, false);
         assert_eq!(config.exit_on_failure, true);
 
         let config = ConfigurationBuilder::default()
             .exit_on_failure(false)
             .build()
             .unwrap();
-        assert_eq!(config.parallel, true);
+
         assert_eq!(config.exit_on_failure, false);
     }
 }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -16,8 +16,6 @@ use std::sync::{Arc, Mutex};
 
 use time::Instant;
 
-use rayon::prelude::*;
-
 use block::Block;
 use block::Context;
 use block::Example;
@@ -48,7 +46,7 @@ impl Runner {
 impl Runner {
     pub fn run<T>(&self, suite: &Suite<T>) -> SuiteReport
     where
-        T: Clone + Send + Sync + ::std::fmt::Debug,
+        T: Clone,
     {
         let mut environment = suite.environment.clone();
         self.prepare_before_run();
@@ -97,20 +95,9 @@ impl Runner {
         result
     }
 
-    fn evaluate_blocks_parallel<T>(&self, context: &Context<T>, environment: &T) -> Vec<BlockReport>
-    where
-        T: Clone + Send + Sync + ::std::fmt::Debug,
-    {
-        context
-            .blocks
-            .par_iter()
-            .map(|block| self.evaluate_block(block, context, environment))
-            .collect()
-    }
-
     fn evaluate_blocks_serial<T>(&self, context: &Context<T>, environment: &T) -> Vec<BlockReport>
     where
-        T: Clone + Send + Sync + ::std::fmt::Debug,
+        T: Clone,
     {
         context
             .blocks
@@ -126,7 +113,7 @@ impl Runner {
         environment: &T,
     ) -> BlockReport
     where
-        T: Clone + Send + Sync + ::std::fmt::Debug,
+        T: Clone,
     {
         let mut environment = environment.clone();
         self.wrap_each(context, &mut environment, |environment| {
@@ -180,7 +167,7 @@ impl Drop for Runner {
 
 impl<T> TestSuiteVisitor<Suite<T>> for Runner
 where
-    T: Clone + Send + Sync + ::std::fmt::Debug,
+    T: Clone,
 {
     type Environment = T;
     type Output = SuiteReport;
@@ -198,7 +185,7 @@ where
 
 impl<T> TestSuiteVisitor<Block<T>> for Runner
 where
-    T: Clone + Send + Sync + ::std::fmt::Debug,
+    T: Clone,
 {
     type Environment = T;
     type Output = BlockReport;
@@ -221,7 +208,7 @@ where
 
 impl<T> TestSuiteVisitor<Context<T>> for Runner
 where
-    T: Clone + Send + Sync + ::std::fmt::Debug,
+    T: Clone,
 {
     type Environment = T;
     type Output = ContextReport;
@@ -232,11 +219,7 @@ where
         }
         let start_time = Instant::now();
         let reports: Vec<_> = self.wrap_all(context, environment, |environment| {
-            if self.configuration.parallel {
-                self.evaluate_blocks_parallel(context, environment)
-            } else {
-                self.evaluate_blocks_serial(context, environment)
-            }
+            self.evaluate_blocks_serial(context, environment)
         });
         let end_time = Instant::now();
         let elapsed_time = end_time - start_time;
@@ -250,7 +233,7 @@ where
 
 impl<T> TestSuiteVisitor<Example<T>> for Runner
 where
-    T: Clone + Send + Sync + ::std::fmt::Debug,
+    T: Clone,
 {
     type Environment = T;
     type Output = ExampleReport;

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -3,8 +3,8 @@
 mod configuration;
 mod observer;
 
-pub use runner::configuration::*;
-pub use runner::observer::*;
+pub use crate::runner::configuration::*;
+pub use crate::runner::observer::*;
 
 use std::borrow::Borrow;
 use std::cell::Cell;
@@ -16,15 +16,15 @@ use std::sync::{Arc, Mutex};
 
 use time::Instant;
 
-use block::Block;
-use block::Context;
-use block::Example;
-use block::Suite;
-use report::ContextReport;
-use report::ExampleReport;
-use report::SuiteReport;
-use report::{BlockReport, Report};
-use visitor::TestSuiteVisitor;
+use crate::block::Block;
+use crate::block::Context;
+use crate::block::Example;
+use crate::block::Suite;
+use crate::report::ContextReport;
+use crate::report::ExampleReport;
+use crate::report::SuiteReport;
+use crate::report::{BlockReport, Report};
+use crate::visitor::TestSuiteVisitor;
 
 /// Runner for executing a test suite's examples.
 pub struct Runner {
@@ -268,7 +268,7 @@ mod tests {
         mod broadcast {
             use super::*;
 
-            use header::*;
+            use crate::header::*;
             use std::sync::atomic::*;
 
             // XXX blank impl for stubbing
@@ -628,8 +628,8 @@ mod tests {
     mod impl_visitor_example_for_runner {
         use super::*;
 
-        use header::*;
-        use report::*;
+        use crate::header::*;
+        use crate::report::*;
         use std::sync::atomic::*;
 
         #[derive(Default, Debug, Clone)]

--- a/src/runner/observer.rs
+++ b/src/runner/observer.rs
@@ -1,8 +1,8 @@
 //! Events are sent by the Runner to signal the progression in the test suite, with the results
 
-use header::{ContextHeader, ExampleHeader, SuiteHeader};
-use report::{ContextReport, ExampleReport, SuiteReport};
-use runner::Runner;
+use crate::header::{ContextHeader, ExampleHeader, SuiteHeader};
+use crate::report::{ContextReport, ExampleReport, SuiteReport};
+use crate::runner::Runner;
 
 /// `RunnerObserver`s can be attached to a [`Runner`](../runner/struct.Runner.html) to observe a
 #[allow(unused_variables)]


### PR DESCRIPTION
It wasn't possible to write tests for objects that is not `Send + Sync` before, this PR solves this problem..
* Removed `rayon` crate (which require Send + Sync) to be able to remove unnecessary restrictions on environment.
* Send, Sync, Debug - removed from environment, as this library only needs to be able to clone environment, nothing else matters to it.
* Also updated to 2018 edition, which affected the way imports are used. This step is required to implement async functionality in the future.
